### PR TITLE
Add projection id to command line on the read models step

### DIFF
--- a/source/includes/_01-your-first-backend-in-10-minutes.md
+++ b/source/includes/_01-your-first-backend-in-10-minutes.md
@@ -196,7 +196,7 @@ The full code for the entity can be seen on the right.
 > New read model
 
 ```bash
-boost new:read-model PostReadModel --fields title:string content:string author:string --projects Post
+boost new:read-model PostReadModel --fields title:string content:string author:string --projects Post:id
 ```
 Almost everything is set-up. We just need to provide a way to view the `Posts` of our blog. For that, we will create a `read model`.
 


### PR DESCRIPTION
This PR fixes an error on the **First read-model** section of the [**Your first Booster app in 10 minutes**](http://docs.booster.cloud/#5-first-read-model) guide.

After running 
```shell
boost new:read-model PostReadModel --fields title:string content:string author:string --projects Post
```

I got this error:

```txt
Error: Error parsing projection Post. Projections must be in the form of <entity name>:<entity id>
    at projectionParsingError (/<homedir>/.nvm/versions/node/v13.12.0/lib/node_modules/@boostercloud/cli/dist/services/generator/target/parsing.js:37:48)
    at parseProjection (/<homedir>/.nvm/versions/node/v13.12.0/lib/node_modules/@boostercloud/cli/dist/services/generator/target/parsing.js:23:15)
    at Array.map (<anonymous>)
    at Object.exports.parseProjections (/<homedir>/.nvm/versions/node/v13.12.0/lib/node_modules/@boostercloud/cli/dist/services/generator/target/parsing.js:19:59)
    at run (/<homedir>/.nvm/versions/node/v13.12.0/lib/node_modules/@boostercloud/cli/dist/commands/new/read-model.js:41:224)
    at ReadModel.runWithErrors (/<homedir>/.nvm/versions/node/v13.12.0/lib/node_modules/@boostercloud/cli/dist/commands/new/read-model.js:22:16)
    at ReadModel.run (/<homedir>/.nvm/versions/node/v13.12.0/lib/node_modules/@boostercloud/cli/dist/commands/new/read-model.js:13:21)
    at ReadModel._run (/<homedir>/.nvm/versions/node/v13.12.0/lib/node_modules/@boostercloud/cli/node_modules/@oclif/command/lib/command.js:43:31)
```

**Initially, I solved the issue by running the command adding the Post ID type (UUID)** like this:

```shell
boost new:read-model PostReadModel --fields title:string content:string author:string --projects Post:UUID
```

It _worked_, it generated this read-model:

```typescript
import { ReadModel, Projects } from '@boostercloud/framework-core'
import { UUID } from '@boostercloud/framework-types'
import { Post } from '../entities/Post'

@ReadModel({
  authorize: // Specify authorized roles here. Use 'all' to authorize anyone
})
export class PostReadModel {
  public constructor(
    public id: UUID,
    readonly title: string,
    readonly content: string,
    readonly author: string,
  ) {}

  @Projects(Post, "UUID") // << --------------- Take a look here
  public static projectPost(entity: Post, currentPostReadModel?: PostReadModel): PostReadModel {
    return /* NEW PostReadModel HERE */
  }

}
```

**But then, it was not working when running the GraphQL query**. After creating the two posts of the tutorial, the query was returning an empty list. **After that, I tried running the command with the projection id attribute name (id), and then both, the command and the query were working as expected**.

```shell
boost new:read-model PostReadModel --fields title:string content:string author:string --projects Post:id
```

That made me wonder:
- Is it possible to verify that the attribute provided in the`new:read-model` command already exists? 
- does it make sense to open an issue in the framework repo to address it?

